### PR TITLE
Updated Honey and Darling All Days logic to not require bombchu bag

### DIFF
--- a/locations/locations/clock_town.jsonc
+++ b/locations/locations/clock_town.jsonc
@@ -404,8 +404,9 @@
           {
             "name": "East Clock Town Honey and Darling All Days",
             "access_rules": [
-              "easy_logic, bow, bombs, $baby_has_bombchus",
-              "normal_logic, bow, bombs, bombchu_bag"
+              "easy_logic, bow, bombs",
+              "normal_logic, bow, bombs",
+              "normal_logic, deku, magic, bombs"
             ]
           }
         ],


### PR DESCRIPTION
Addresses #14

## Changes
- No longer requires bombchu bag
- Added Deku + Magic to logic as alternative to Bow to match Any Day logic

## Testing
I packaged the .zip and tested this in PopTracker to make sure that the check opens up under this logic

<img width="754" height="550" alt="image" src="https://github.com/user-attachments/assets/9c3e6b4d-b637-4431-a895-bfd335c70200" />

<img width="699" height="563" alt="image" src="https://github.com/user-attachments/assets/5475bef5-a67e-4c47-ac14-198cb77a1a81" />
